### PR TITLE
move tape to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "test": "test"
   },
   "dependencies": {
-    "tape": "^4.0.0"
   },
   "devDependencies": {
-    "oriented-simplicial-complex-compare": "^1.0.0"
+    "oriented-simplicial-complex-compare": "^1.0.0",
+    "tape": "^4.0.0"
   },
   "scripts": {
     "test": "tape test/*.js"


### PR DESCRIPTION
`tape` is not a dependency of this module.

@mikolalysenko 